### PR TITLE
[#IR-70] Update naming conventions on Retrospective list, dashboard and create page

### DIFF
--- a/src/app/retrospective/retrospective-create/retrospective-create.component.html
+++ b/src/app/retrospective/retrospective-create/retrospective-create.component.html
@@ -1,20 +1,15 @@
 <div class="create-retro" [formGroup]="retroFormGroup" *ngIf="isTeamOptionsLoaded && isProviderOptionsLoaded">
-  <h2 mat-dialog-title>Create a New Retro</h2>
+  <h2 mat-dialog-title>Create Team Retrospective</h2>
   <mat-grid-list cols="2" rowHeight="250px">
     <mat-grid-tile>
       <mat-card>
         <mat-card-header>
-          <mat-card-title><b>Retrospective Details</b></mat-card-title>
+          <mat-card-title><b>Team Retrospective Details</b></mat-card-title>
         </mat-card-header>
         <mat-card-content>
           <div>
             <mat-form-field>
-              <input matInput formControlName="title" placeholder="Retrospective Title">
-            </mat-form-field>
-          </div>
-          <div>
-            <mat-form-field>
-              <input matInput type="number" formControlName="storyPointPerWeek"
+              <input matInput type="number" min="0" formControlName="storyPointPerWeek"
                      placeholder="Expected Story Point Per Week Per Person">
             </mat-form-field>
           </div>
@@ -36,7 +31,8 @@
           </div>
           <div>
             <mat-form-field>
-              <input matInput formControlName="projectName" placeholder="Specify Project Name">
+              <input matInput formControlName="projectName" placeholder="Specify Project Name (Comma Separated)">
+              <mat-hint class="project-name-hint">Used by time provider</mat-hint>
             </mat-form-field>
           </div>
         </mat-card-content>

--- a/src/app/retrospective/retrospective-create/retrospective-create.component.scss
+++ b/src/app/retrospective/retrospective-create/retrospective-create.component.scss
@@ -23,3 +23,7 @@ button .mat-raised-button {
   color: white;
   background-color: #3293be;
 }
+
+.project-name-hint {
+  font-size: small;
+}

--- a/src/app/retrospective/retrospective-create/retrospective-create.component.ts
+++ b/src/app/retrospective/retrospective-create/retrospective-create.component.ts
@@ -84,7 +84,6 @@ export class RetrospectiveCreateComponent implements OnInit {
 
     createRetroFormGroup() {
         this.retroFormGroup = new FormGroup({
-            'title': new FormControl('', Validators.required),
             'team': new FormControl('', Validators.required),
             'storyPointPerWeek': new FormControl('', Validators.required),
             'projectName': new FormControl('', Validators.required),
@@ -101,8 +100,9 @@ export class RetrospectiveCreateComponent implements OnInit {
 
     createRetro(formValue) {
         this.disableButton = true;
+        const selectedTeam = this.teamOptions.filter(team => team.ID === formValue.team)[0];
         const requestBody = {
-            'title': formValue.title,
+            'title': selectedTeam && selectedTeam.Name || '',
             'team': formValue.team,
             'storyPointPerWeek': formValue.storyPointPerSprint,
             'projectName': formValue.projectName,

--- a/src/app/retrospective/retrospective-dashboard/retrospective-dashboard.component.html
+++ b/src/app/retrospective/retrospective-dashboard/retrospective-dashboard.component.html
@@ -2,16 +2,15 @@
   <div *ngIf="isDataLoaded">
     <mat-card class="retro-details">
       <div *ngIf="retrospectiveData">
-        <span><b>{{ retrospectiveData.Title }}</b></span>&nbsp;|&nbsp;
-        <span>Project:<b> {{ retrospectiveData.ProjectName }}</b></span>&nbsp;|&nbsp;
         <span>Team: <b>{{ retrospectiveData.Team.Name }}</b></span>&nbsp;|&nbsp;
+        <span>Project:<b> {{ retrospectiveData.ProjectName }}</b></span>&nbsp;|&nbsp;
         <span>Created At: <b>{{ retrospectiveData.CreatedAt | date:dateFormat}}</b></span>&nbsp;|&nbsp;
         <span>Created By: <b>{{ getCreatorName() }}</b></span>&nbsp;|&nbsp;
         <span>Expected Story Point Per Week Per Person: <b>{{ retrospectiveData.StoryPointPerWeek}}</b></span>
       </div>
       <div class="action-buttons">
         <button mat-raised-button class="add-sprint" (click)="showNewSprintDialog()">
-          Add a New Sprint
+          Create
         </button>
       </div>
     </mat-card>

--- a/src/app/retrospective/retrospective-list/retrospective-list.component.html
+++ b/src/app/retrospective/retrospective-list/retrospective-list.component.html
@@ -2,32 +2,22 @@
   <div class="retro-list-container">
     <mat-card class="retro-list-header">
       <div>
-        <span><b>Retrospectives</b></span>
+        <span><b>Team Retrospectives</b></span>
       </div>
       <div class="action-buttons">
-        <button mat-raised-button (click)="showCreateRetroModal()">Create a New Retro</button>
+        <button mat-raised-button (click)="showCreateRetroModal()">Create</button>
       </div>
     </mat-card>
     <div class="retro-table-content">
       <div class="retro-table-container mat-elevation-z5">
         <mat-table #table class="custom-mat-table" [dataSource]="dataSource">
-          <!-- Title Column -->
-          <ng-container matColumnDef="title">
-            <mat-header-cell *matHeaderCellDef>Title</mat-header-cell>
+          <!-- Team Column -->
+          <ng-container matColumnDef="team">
+            <mat-header-cell *matHeaderCellDef>Team</mat-header-cell>
             <mat-cell *matCellDef="let element"
                       (click)="navigateToRetrospectiveDetail(element)">
               <span matTooltip="Link to the Retrospective Dashboard" class="retro-dashboard-link">{{element.Title}}</span>
             </mat-cell>
-            <!--<mat-cell *matCellDef="let element">-->
-              <!--<span class="link-type-cell"-->
-                    <!--matTooltip="Link to Retrospective Dashboard">{{element.Title}}</span>-->
-            <!--</mat-cell>-->
-          </ng-container>
-
-          <!-- Team Column -->
-          <ng-container matColumnDef="team">
-            <mat-header-cell *matHeaderCellDef>Team</mat-header-cell>
-            <mat-cell *matCellDef="let element"> {{element.Team.Name}}</mat-cell>
           </ng-container>
 
           <!-- Created At Column -->

--- a/src/app/retrospective/retrospective-list/retrospective-list.component.ts
+++ b/src/app/retrospective/retrospective-list/retrospective-list.component.ts
@@ -14,7 +14,7 @@ import { RetrospectiveCreateComponent } from '../retrospective-create/retrospect
 })
 export class RetrospectiveListComponent implements OnInit {
     dataSource: RetrospectiveListDataSource;
-    displayedColumns = ['title', 'team', 'updated_at', 'latest_sprint'];
+    displayedColumns = ['team', 'updated_at', 'latest_sprint'];
 
     constructor(private retrospectiveService: RetrospectiveService,
                 private snackBar: MatSnackBar,

--- a/src/app/retrospective/sprint-create/sprint-create.component.html
+++ b/src/app/retrospective/sprint-create/sprint-create.component.html
@@ -1,5 +1,5 @@
 <div class="create-sprint"  [formGroup]="sprintFormGroup">
-  <h2 mat-dialog-title>Create a New Sprint</h2>
+  <h2 mat-dialog-title>Create Sprint Retrospective</h2>
   <div>
     <mat-form-field>
       <input matInput formControlName="title" placeholder="Sprint Title" required>


### PR DESCRIPTION
### Changes done:
- Rename Retrospective table header to Team Retrospective
- Display Team name in Title column, Hide Team Column
- Hide Title field from Retro create
- Rename sprint to Sprint Retrospective
- Change "create a new retro/sprint" to "create"
- Update "Hours per story point" to "Story Points per week"
- Update "Project Name" to denote that it is for the time provider