### PR TITLE
[#IR-290] Fix typo - remove 's' from "sRetrospective Title"

### DIFF
--- a/src/app/retrospective/retrospective-list/retrospective-list.component.html
+++ b/src/app/retrospective/retrospective-list/retrospective-list.component.html
@@ -15,7 +15,7 @@
                         <mat-table #table class="custom-mat-table -row-clickable" [dataSource]="dataSource">
                             <!-- Title Column -->
                             <ng-container matColumnDef="title">
-                                <mat-header-cell *matHeaderCellDef>sRetrospective Title</mat-header-cell>
+                                <mat-header-cell *matHeaderCellDef>Retrospective Title</mat-header-cell>
                                 <mat-cell *matCellDef="let element">
                                     <a class="retro-dashboard-link"
                                        matTooltip="Link to the Retrospective Dashboard"


### PR DESCRIPTION
Fix typo in the retrospective list page, an extra 's' is present at the starting of the column header "Retrospective Title".