### PR TITLE
[#IR-255] Suppress keyboard events for the 'Text' field under the notes and highlights section

### DIFF
--- a/src/app/retrospective/retrospective-feedback/retrospective-feedback.component.ts
+++ b/src/app/retrospective/retrospective-feedback/retrospective-feedback.component.ts
@@ -22,6 +22,7 @@ import { UtilsService } from '../../shared/utils/utils.service';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/takeUntil';
 import { environment } from '../../../environments/environment';
+import { SuppressKeyboardEventParams } from 'ag-grid/src/ts/entities/colDef';
 
 @Component({
     selector: 'app-retrospective-feedback',
@@ -342,6 +343,7 @@ export class RetrospectiveFeedbackComponent implements OnInit, OnChanges, OnDest
                         this.updateRetroFeedback(cellParams);
                     }
                 },
+                suppressKeyboardEvent: (event: SuppressKeyboardEventParams) => this.utils.isAgGridEditingEvent(event),
                 filter: 'agTextColumnFilter',
                 filterParams: {
                     newRowsAction: 'keep',


### PR DESCRIPTION
Notes and Highlights `Text` field doesn't has keyboard events suppressed so the user has to press Shift + Enter to go to a new line, while in other parts of the application, a textbox edit suppresses keyboard events until the edit is complete, which should be consistent throughout the application.